### PR TITLE
Add CreatorId header on create

### DIFF
--- a/lib/esignatur/order.rb
+++ b/lib/esignatur/order.rb
@@ -20,7 +20,9 @@ module Esignatur
     end
 
     def create(attributes)
-      response = api_post('Order/Create', attributes)
+      camelized_attributes = attributes.transform_keys { _1.to_s.camelize }
+      headers = { 'X-eSignatur-CreatorId' => camelized_attributes['CreatorId'].to_s }
+      response = api_post('Order/Create', attributes, headers: headers)
       if errors.empty?
         body = response.json_body
         @attributes = attributes.merge(id: body.fetch('OrderId')).merge(body)

--- a/spec/lib/esignatur/order_spec.rb
+++ b/spec/lib/esignatur/order_spec.rb
@@ -38,6 +38,11 @@ module Esignatur
         expect(create_order_request).to have_been_made
       end
 
+      it 'includes "X-eSignatur-CreatorId" header' do
+        create
+        expect(create.last_response.request.headers['X-eSignatur-CreatorId']).to eq('1')
+      end
+
       it 'returns Order instance' do
         expect(create).to be_an(Order)
       end


### PR DESCRIPTION
This PR changes how `Oder/Create` works.

`#create` method now takes `CreatorId` field from passed attributes and adds it to `X-eSignatur-CreatorId` HTTP header.